### PR TITLE
`FFITypeAlias` can be a formatter to process nested templates. e.g.,

### DIFF
--- a/annotation-processor/src/test/java/com/alibaba/fastffi/annotation/TestFFITypeAlias.java
+++ b/annotation-processor/src/test/java/com/alibaba/fastffi/annotation/TestFFITypeAlias.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright 1999-2021 Alibaba Group Holding Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.alibaba.fastffi.annotation;
+
+import com.google.testing.compile.Compilation;
+import org.junit.Test;
+
+import java.io.IOException;
+import java.util.regex.Pattern;
+
+import static com.google.testing.compile.CompilationSubject.assertThat;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+public class TestFFITypeAlias
+        extends TestBase {
+    @Test
+    public void test() throws IOException {
+        Compilation compilation = compile(this.getClass());
+        assertThat(compilation).succeeded();
+        {
+            String content = readJavaCode(compilation, "jni_samples_FFITypeAliasSample_cxx_0xd5bc344f.cc");
+            assertTrue(content.contains("FFITypeAliasSample<bool>"));
+        }
+        {
+            String content = readJavaCode(compilation, "jni_samples_FFITypeAliasSample_Inner_cxx_0x29f7575b.cc");
+            assertTrue(content.contains("FFITypeAliasSample<bool>::Inner<uint32_t>"));
+            assertFalse(content.contains("FFITypeAliasSample::Inner<bool, uint32_t>"));
+        }
+    }
+}

--- a/annotation-processor/src/test/java/com/alibaba/fastffi/annotation/TestFFITypeAlias.java
+++ b/annotation-processor/src/test/java/com/alibaba/fastffi/annotation/TestFFITypeAlias.java
@@ -19,7 +19,6 @@ import com.google.testing.compile.Compilation;
 import org.junit.Test;
 
 import java.io.IOException;
-import java.util.regex.Pattern;
 
 import static com.google.testing.compile.CompilationSubject.assertThat;
 import static org.junit.Assert.assertFalse;
@@ -39,6 +38,23 @@ public class TestFFITypeAlias
             String content = readJavaCode(compilation, "jni_samples_FFITypeAliasSample_Inner_cxx_0x29f7575b.cc");
             assertTrue(content.contains("FFITypeAliasSample<bool>::Inner<uint32_t>"));
             assertFalse(content.contains("FFITypeAliasSample::Inner<bool, uint32_t>"));
+        }
+        {
+            String content = readJavaCode(compilation, "jni_samples_FFITypeAliasSample2_cxx_0x1d1e7d2c.cc");
+            assertTrue(content.contains("FFITypeAliasSample2<double>"));
+        }
+        {
+            String content = readJavaCode(compilation, "jni_samples_FFITypeAliasSample2_ArrayType2_cxx_0xd473eb.cc");
+            assertTrue(content.contains("FFITypeAliasSample2<double>::ArrayType2"));
+            assertFalse(content.contains("FFITypeAliasSample2::ArrayType2<double>"));
+        }
+        {
+            String content = readJavaCode(compilation, "jni_samples_shared_ptr_cxx_0xb705fdd4.cc");
+            assertTrue(content.contains("std::shared_ptr<int>"));
+        }
+        {
+            String content = readJavaCode(compilation, "jni_samples_shared_ptr_element_type_cxx_0xdfc088b1.cc");
+            assertTrue(content.contains("std::shared_ptr<int>::element_type"));
         }
     }
 }

--- a/annotation-processor/src/test/resources/samples/FFITypeAliasSample.java
+++ b/annotation-processor/src/test/resources/samples/FFITypeAliasSample.java
@@ -15,8 +15,14 @@
  */
 package samples;
 import com.alibaba.fastffi.CXXHead;
+import com.alibaba.fastffi.CXXPointer;
+import com.alibaba.fastffi.CXXReference;
 import com.alibaba.fastffi.CXXTemplate;
+import com.alibaba.fastffi.CXXValue;
+import com.alibaba.fastffi.FFIExpr;
+import com.alibaba.fastffi.FFIFactory;
 import com.alibaba.fastffi.FFIGen;
+import com.alibaba.fastffi.FFIGenBatch;
 import com.alibaba.fastffi.FFIPointer;
 import com.alibaba.fastffi.FFITypeAlias;
 
@@ -31,5 +37,69 @@ public interface FFITypeAliasSample<T> extends FFIPointer {
     @CXXTemplate(cxx = {"bool", "uint32_t"}, java = {"Boolean", "Integer"})
     interface Inner<T, U> extends FFIPointer {
         void api2(T t, U u);
+    }
+}
+
+@FFITypeAlias("FFITypeAliasSample2")
+@FFIGen(templates = {@CXXTemplate(cxx = "double", java = "java.lang.Double")})
+interface FFITypeAliasSample2<T> extends FFIPointer
+{
+    int get0();
+
+    ArrayType2<T> get2();
+
+    @FFITypeAlias("FFITypeAliasSample2<%s>::ArrayType2")
+    @FFIGen(templates = {@CXXTemplate(cxx="double", java = "java.lang.Double")})
+    interface ArrayType2<T> extends CXXPointer
+    {
+    }
+}
+
+@FFITypeAlias("std::shared_ptr")
+@FFIGen(templates = {
+        @CXXTemplate(cxx = "int", java = "Integer")
+})
+@CXXHead(
+        system = "__memory/shared_ptr.h"
+)
+@CXXHead(
+        system = "memory"
+)
+interface shared_ptr<_Tp> extends CXXPointer {
+    void swap(@CXXReference shared_ptr<_Tp> __r);
+
+    void reset();
+
+    element_type<_Tp> get();
+
+    int use_count();
+
+    boolean unique();
+
+    boolean __owner_equivalent(@CXXReference shared_ptr<_Tp> __p);
+
+    @FFIFactory
+    @CXXHead(
+            system = "__memory/shared_ptr.h"
+    )
+    @CXXHead(
+            system = "memory"
+    )
+    interface Factory<_Tp> {
+        shared_ptr<_Tp> create();
+
+        shared_ptr<_Tp> create(@CXXReference shared_ptr<_Tp> __r);
+    }
+
+    @FFITypeAlias("std::shared_ptr<%s>::element_type")
+    @FFIGen(templates = {
+            @CXXTemplate(cxx = "int", java = "Integer")
+    })
+    @CXXHead(
+            system = "__memory/shared_ptr.h"
+    )
+    interface element_type<_Tp> extends CXXPointer {
+        @FFIExpr("{0}")
+        _Tp get();
     }
 }

--- a/annotation-processor/src/test/resources/samples/FFITypeAliasSample.java
+++ b/annotation-processor/src/test/resources/samples/FFITypeAliasSample.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright 1999-2021 Alibaba Group Holding Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package samples;
+import com.alibaba.fastffi.CXXHead;
+import com.alibaba.fastffi.CXXTemplate;
+import com.alibaba.fastffi.FFIGen;
+import com.alibaba.fastffi.FFIPointer;
+import com.alibaba.fastffi.FFITypeAlias;
+
+@FFIGen(library = "FFITypeAliasSample")
+@FFITypeAlias("FFITypeAliasSample")
+@CXXTemplate(cxx = "bool", java = "Boolean")
+public interface FFITypeAliasSample<T> extends FFIPointer {
+    void api1(T t);
+
+    @FFIGen(library = "FFITypeAliasSample.Inner")
+    @FFITypeAlias("FFITypeAliasSample<%1$s>::Inner<%2$s>")
+    @CXXTemplate(cxx = {"bool", "uint32_t"}, java = {"Boolean", "Integer"})
+    interface Inner<T, U> extends FFIPointer {
+        void api2(T t, U u);
+    }
+}


### PR DESCRIPTION
```cpp
template <typename T>
class A {
    class B {
    };
};
```

With the following java annotation:

```java
@FFITypeAlias("A")
public interface<T> {
};

@FFITypeAlias("A::B")
public interface B<T> {
}
```

Note that `A::B` will be rendered as `A::B<T>`, however it should be `A<T>::B`.

After this pull request the the `FFITypeAlias` could be `A<%1$s>::B`.

Resolves #20 